### PR TITLE
Use cp_explode(), and register escaped values

### DIFF
--- a/languages/appthemes-wpml.pot
+++ b/languages/appthemes-wpml.pot
@@ -1,36 +1,37 @@
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AppThemes WPML Bridge 1.0\n"
+"Project-Id-Version: AppThemes WPML Bridge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-02-14 16:07+0100\n"
+"POT-Creation-Date: 2016-09-07 21:33+0200\n"
 "PO-Revision-Date: 2013-02-14 16:07+0100\n"
 "Last-Translator: AppThemes\n"
 "Language-Team: AppThemes\n"
-"Language: English\n"
+"Language: en\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Poedit 1.5.5\n"
+"X-Generator: Poedit 1.8.9\n"
 "X-Poedit-KeywordsList: __;_e;_n:1,2;_nx:1,2;_x:1,2c;_ex:1,2c;esc_attr__;"
-"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
-"_nx_noop:1,2,3c\n"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;"
+"_n_noop:1,2;_nx_noop:1,2,3c\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-Basepath: .\n"
 "X-Poedit-SearchPath-0: ..\n"
 
-#: ../wpml.php:55
+#: ../wpml.php:75
 msgid "AppThemes WPML Bridge could not run."
 msgstr ""
 
-#: ../wpml.php:58
+#: ../wpml.php:78
 msgid "AppThemes WPML Bridge does not support the current theme."
 msgstr ""
 
-#: ../wpml.php:61
+#: ../wpml.php:82
 msgid "AppThemes WPML Bridge require WPML Multilingual CMS plugin to work."
 msgstr ""
 
-#: ../wpml.php:64
+#: ../wpml.php:86
 msgid "AppThemes WPML Bridge require WPML String Translation plugin to work."
 msgstr ""

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === AppThemes WPML Bridge ===
 Contributors: appthemes
 Tags: appthemes, wpml, integration, language, localization, multilingual, classipress
-Requires at least: 3.4
-Tested up to: 3.6
-Stable tag: 1.2
+Requires at least: 4.0
+Tested up to: 4.6.1
+Stable tag: 1.3
 
 This plugin adds additional WPML compatibility for AppThemes themes.
 
@@ -42,6 +42,13 @@ Report it with details on [AppThemes support forum](http://forums.appthemes.com/
 
 
 == Changelog ==
+
+= 1.3 =
+
+* Use new function cp_explode() to properly handle checkbox values
+* Register in WPML also escaped checkbox values
+* Corrected loading plugin textdomain
+* Fix typo in variable name
 
 = 1.2 =
 

--- a/wpml.php
+++ b/wpml.php
@@ -1,32 +1,41 @@
 <?php
 /*
 Plugin Name: AppThemes WPML Bridge
+Plugin URI: https://docs.appthemes.com/wpml-bridge-plugin/
 Description: Creates bridge between AppThemes Products and WPML plugin.
 
 AppThemes ID: appthemes-wpml
 
-Version: 1.2
+Version: 1.3
 Author: AppThemes
 Author URI: http://appthemes.com
 Text Domain: appthemes-wpml
+Domain Path: /languages
 */
 
 
 /**
  * Plugin version and textdomain constants.
  */
-define( 'APP_WPML_VERSION', '1.1' );
+define( 'APP_WPML_VERSION', '1.3' );
 define( 'APP_WPML_TD', 'appthemes-wpml' );
 
 
 /**
  * Load Text-Domain.
+ *
+ * @return void
  */
-load_plugin_textdomain( APP_WPML_TD, false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+function app_wpml_load_textdomain() {
+	load_plugin_textdomain( APP_WPML_TD, false, dirname( plugin_basename( __FILE__ ) ) . '/languages/' );
+}
+add_action( 'plugins_loaded', 'app_wpml_load_textdomain' );
 
 
 /**
  * Setup the WPML Bridge.
+ *
+ * @return void
  */
 function app_wpml_setup() {
 
@@ -36,13 +45,15 @@ function app_wpml_setup() {
 		return;
 	}
 
-	require_once dirname( __FILE__ ) . '/wpml-actions.php';
+	require_once( dirname( __FILE__ ) . '/wpml-actions.php' );
 }
 add_action( 'plugins_loaded', 'app_wpml_setup' );
 
 
 /**
  * Check for existence of AppThemes Products.
+ *
+ * @return void
  */
 function app_wpml_check_appthemes() {
 
@@ -56,19 +67,24 @@ add_action( 'init', 'app_wpml_check_appthemes' );
 
 /**
  * Displays warning when AppThemes Theme or WPML plugin is not installed.
+ *
+ * @return void
  */
 function app_wpml_display_warning() {
 
 	$message = __( 'AppThemes WPML Bridge could not run.', APP_WPML_TD );
 
-	if ( ! function_exists( 'appthemes_init' ) )
+	if ( ! function_exists( 'appthemes_init' ) ) {
 		$message = __( 'AppThemes WPML Bridge does not support the current theme.', APP_WPML_TD );
+	}
 
-	if ( ! defined( 'ICL_SITEPRESS_VERSION' ) )
+	if ( ! defined( 'ICL_SITEPRESS_VERSION' ) ) {
 		$message = __( 'AppThemes WPML Bridge require WPML Multilingual CMS plugin to work.', APP_WPML_TD );
+	}
 
-	if ( ! defined( 'WPML_ST_VERSION' ) )
+	if ( ! defined( 'WPML_ST_VERSION' ) ) {
 		$message = __( 'AppThemes WPML Bridge require WPML String Translation plugin to work.', APP_WPML_TD );
+	}
 
 	echo '<div class="error fade"><p>' . $message . '</p></div>';
 	deactivate_plugins( plugin_basename( __FILE__ ) );


### PR DESCRIPTION
 - use new function cp_explode()
 - fixed variable typo ```$value```
 - corrected loading plugin textdomain
 - registered in wpml also escaped versions of checkbox values
 - bumped versions (plugin, tested, required)
 - updated readme