### PR TITLE
Update wpml-actions.php

### DIFF
--- a/wpml-actions.php
+++ b/wpml-actions.php
@@ -171,7 +171,7 @@ function app_wpml_cp_formbuilder_field( $result ) {
 			$new_options[] = icl_t( APP_TD, 'value_' . $result->field_name . ' ' . trim( $option ), $option );
 		}
 
-		$result->field_values = implode( $new_options, ',' );
+		$result->field_values = implode( ',', $new_options );
 	}
 
 	return $result;


### PR DESCRIPTION
Passing glue string after array is deprecated.